### PR TITLE
ci: add pull-requests:read to actionlint caller permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,3 +13,4 @@ jobs:
     permissions:
       checks: write
       contents: read
+      pull-requests: read


### PR DESCRIPTION
## Summary
- Adds `pull-requests: read` to the actionlint job permissions, matching the new requirement from the upstream `reusable-actionlint.yml` (SchweizerischeBundesbahnen/github-workflows-polarion#57).
- Without this, PR runs fail with `startup_failure`.

Closes #161

## Test plan
- [ ] Verify ActionLint workflow runs successfully on this PR