### PR TITLE
ci: add actions:read to claude-code-review caller permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ jobs:
   claude-review:
     uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary

Adds the missing `actions: read` line to the `claude-code-review.yml` caller. The upstream reusable workflow declares `actions: read` at the job level (needed for the claude-code-action `github_ci` MCP server), but a caller's job-level `permissions:` block **replaces** (not merges with) the reusable workflow's permissions, so consumers must grant it themselves.

The python and java Polarion templates already grant `actions: read`; this brings the docker template into line so newly bootstrapped repos don't hit `startup_failure` on the first non-bot PR that triggers `claude-review`.

## Why this didn't surface here

Renovate PRs are skipped by `if: !contains(github.event.pull_request.user.login, '[bot]')`, so this template repo has never exercised the broken code path.

## Related

- Closes #166
- Upstream reusable workflow that added the requirement: SchweizerischeBundesbahnen/github-workflows-polarion#55
- Same class of fix as #161 (`pull-requests: read` for actionlint)
- Downstream consumer hit + fixed in: SchweizerischeBundesbahnen/weasyprint-service#331

## Test plan

- [x] \`pre-commit run\` passes locally on the changed file
- [ ] CI green on this PR