### PR TITLE
ci: inline docker tags, drop unreachable else branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,33 +88,17 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
-      - name: 🧱 Prepare tags for Docker meta
-        id: tags
-        env:
-          # When release-please is skipped, these values will be empty
-          release_created: ${{ needs.release-please.outputs.release_created }}
-          version: ${{ needs.release-please.outputs.version }}
-        run: |
-          tags=""
-          if [[ "$release_created" = 'true' ]]; then
-            tags="type=semver,pattern={{version}},value=$version
-          type=semver,pattern={{major}},value=$version
-          type=semver,pattern={{major}}.{{minor}},value=$version"
-          else
-            tags="type=ref,event=branch
-          type=ref,event=pr"
-          fi
-          {
-            echo 'tags<<EOF'
-            echo "$tags"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: 🧱 Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        env:
+          version: ${{ needs.release-please.outputs.version }}
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.version }}
+            type=semver,pattern={{major}},value=${{ env.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.version }}
       - name: 🧱 Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
       - name: 🧱 Set up Docker Buildx


### PR DESCRIPTION
## Summary

Removes the unreachable `else` branch in the `docker-build-and-publish` tag-prep step (issue #164) by inlining the semver tags directly into `docker/metadata-action` (the issue's **Option B**). Net `-22/+6` lines.

### Why the `else` is dead

The job is gated at job-level with:

```yaml
if: ${{ needs.release-please.outputs.release_created == 'true' }}
```

So by the time the `tag-prep` step runs, `release_created` is guaranteed to be `'true'` — the `else` branch (which set `type=ref,event=branch / type=ref,event=pr`) can never execute. The misleading shape **caused real confusion** in a downstream consumer (pandoc-service#159 traced a stale `:main` GHCR tag back to this exact pattern).

### What changed

- Drop the shell `tag-prep` step (~20 lines of `if/else/heredoc/GITHUB_OUTPUT`)
- Inline the three semver tag patterns directly into `docker/metadata-action`'s `tags:` input

No functional change in the production code path — the `release_created == 'true'` branch produced exactly these three semver tags, and the new step produces the same three semver tags.

## Related

- Closes #164
- Downstream consumer tracking: SchweizerischeBundesbahnen/pandoc-service#159 (will need a follow-up sync to drop the same dead code locally)

## Test plan

- [x] `pre-commit run -a` passes (actionlint + zizmor + yaml all green)
- [ ] CI green on this PR