### PR TITLE
chore: adopt the shared ruff standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,15 @@ repos:
         language: system
         types: [python]
       # Run the linter (inherits config from pyproject.toml)
+      # The tests are linted through per-file-ignores, not excluded — see the
+      # "tests/**" table in pyproject.toml. An exclude here would put them back
+      # out of scope at commit time and make that table dead config locally.
       - id: ruff-check
         name: ruff linter
         entry: uv run ruff check
         language: system
         types: [python]
         args: [--fix]
-        exclude: ^tests/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,37 +48,84 @@ package = false
 line-length = 240
 fix = true
 show-fixes = true
-exclude = [
-    "tests/*"  # Exclude all test files from linting
-]
 
 [tool.ruff.lint]
-extend-select = [
-    # --- Recommended ---
-    "E", "W", # pycodestyle errors and warnings
-    "F",      # Pyflakes
-    "I",      # isort
-    "C4",     # flake8-comprehensions
-    "C90",    # mccabe
-    "B",      # flake8-bugbear
-    "UP",     # pyupgrade
-    "S",      # flake8-bandit
-    "PL",     # Pylint
-    "PTH",    # flake8-pathlib
-    "TCH",    # type-checking imports
-    "SIM",    # flake8-simplify
-    "T20",    # flake8-print
-    "ERA",    # eradicate
+# Shared standard for all SBB Python repositories.
+# Never use extend-select: it inherits ruff's implicit default, which widened in
+# ruff 0.16 and broke CI everywhere. Keep preview off, preview rules churn.
+#
+# ALL still means "every stable rule in the installed ruff", so a ruff bump can
+# introduce findings. That is the accepted trade: a clean bump automerges, and a
+# dirty one turns the new rules into a change someone reads. What this config
+# removes is the version dependency we did not choose and could not see.
+select = ["ALL"]
+preview = false
+ignore = [
+    # ruff format owns this formatting decision. COM812 is the only rule ruff
+    # itself reports as conflicting; the Q00x rules were measured across all
+    # eight repositories and silence nothing, so quote-style below carries that
+    # decision instead of an ignore.
+    "COM812",  # trailing comma
+
+    # Not our convention
+    "D",       # docstrings are optional, we mandate no docstring style
+    "CPY001",  # we ship no copyright headers
+    "FIX002",  # a TODO is a normal marker, not a defect; TD002 and TD003 still
+               # require it to name an author and link an issue
+    "EM101",   # a literal at the raise site reads better than a temp name
+    "EM102",   # same for an f-string
+    "TRY003",  # we want the full message where the raise happens
+    "TRY400",  # a handled error is logged without a traceback
+    "TRY401",  # the exception text belongs on the log line, not only in the traceback
+    "G004",    # we ingest plain log lines, not templates, so f-strings are fine
+    "ANN401",  # Any is correct at JSON and **kwargs boundaries
+    "FBT001",  # a boolean query parameter is part of the HTTP API
+    "FBT002",  # same, with a default
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.pylint]
+max-args = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
-    "S101", # No assert rule (bandit)
-    "PLR2004", # No magic values (pylint)
+    "S101",    # assert is how a test states its expectation
+    "S105",    # test credentials are fake by construction
+    "S106",    # same, passed as an argument
+    "S108",    # a temp path in a test is not a shared temp path
+    "S603",    # tests run known helper binaries
+    "S607",    # those binaries come from PATH on purpose
+    "SLF001",  # a test may assert on internal state
+    "PLC0415", # a local import is how a test patches a module
+    "ANN",     # a test signature carries no type information
+    "ARG",     # a fixture argument is used by pytest, not by the body
+    "PLR2004", # a literal is readable test data
+    "PT",      # unittest style is allowed next to pytest style
+    "E402",    # a test may import after patching
+    "TC",      # a test module is imported once, deferring imports buys nothing
+    "S104",    # a host string in test data is not a binding
+    "S314",    # a test parses the XML fixture it wrote itself
+    "FBT003",  # mock.patch takes the replacement value positionally
+    "C901",    # a fixture is linear setup, splitting it hides the order
+    "PLR0912", # same, for its branches
+    "PLR0915", # same, for its statements
 ]
+
+# Repository-specific per-file ignores belong below this line, each with a
+# reason, and each in the "glob" = ["RULE"] form of the table above.
+#
+# A repository-wide ignore does NOT go here. This is still
+# [tool.ruff.lint.per-file-ignores], so a bare ignore = ["RULE"] parses as a
+# glob named "ignore" that matches no file: it is accepted, it silences
+# nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
 [tool.ruff.format]
 line-ending = "lf"
+# Pinned rather than left to the default: it is what makes the Q00x lint rules
+# redundant, so the decision has to be stated where the formatter reads it.
+quote-style = "double"
 
 [tool.mypy]
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ max-args = 10
 inline-quotes = "double"
 multiline-quotes = "double"
 docstring-quotes = "double"
+# The fourth option, and the one that decides whether Q003 runs at all: set it to
+# false and the rule stops reporting with nothing red to show for it.
+avoid-escape = true
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,12 @@ select = ["ALL"]
 preview = false
 ignore = [
     # ruff format owns this formatting decision. COM812 is the only rule ruff
-    # itself reports as conflicting; the Q00x rules were measured across all
-    # eight repositories and silence nothing, so quote-style below carries that
-    # decision instead of an ignore.
+    # itself reports as conflicting, so it is the only entry here. The Q00x rules
+    # are deliberately absent rather than ignored: Q000, Q002 and Q003 fire
+    # nowhere across the eight repositories, and Q001 fires in one of them but is
+    # auto-fixable and ruff format runs before ruff check in both tox.ini and
+    # pre-commit, so the formatter resolves it. The quote decision itself is
+    # pinned at the bottom of this file, on both the format and the lint side.
     "COM812",  # trailing comma
 
     # Not our convention
@@ -121,10 +124,18 @@ max-args = 10
 # glob named "ignore" that matches no file: it is accepted, it silences
 # nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
+[tool.ruff.lint.flake8-quotes]
+# The lint half of the quote decision. These are what Q000, Q001 and Q002 read,
+# and with the Q rules enabled they decide a lint result, so they are stated
+# rather than inherited. Keep them equal to format.quote-style below: diverge and
+# Q000 fires on the string the formatter just rewrote.
+inline-quotes = "double"
+multiline-quotes = "double"
+docstring-quotes = "double"
+
 [tool.ruff.format]
 line-ending = "lf"
-# Pinned rather than left to the default: it is what makes the Q00x lint rules
-# redundant, so the decision has to be stated where the formatter reads it.
+# The format half. Changing this means changing flake8-quotes above in step.
 quote-style = "double"
 
 [tool.mypy]


### PR DESCRIPTION
Closes #169.

Configuration only — verified with the pinned `ruff==0.16.2` that
`ruff format --check` and `ruff check` both pass across all ten Python files, so
no code had to change.

## Enabled rule count

Counted from `ruff check --show-settings`, the stable rules under
`linter.rules.enabled`:

| Configuration | ruff 0.15.22 | ruff 0.16.2 |
| --- | --- | --- |
| `extend-select`, 15 prefixes (before) | 399 | 580 |
| `select = ["ALL"]`, `preview = false` (after) | — | 754 |

The 181-rule gap across two ruff versions is the version dependency this removes.
`extend-select` inherits ruff's implicit default, which widened in 0.16; nobody
chose those rules and nobody could see them in the configuration.

## The tests were linted by nobody

Two exclusions applied at once, so the declared `per-file-ignores` for
`"tests/**"` silenced nothing:

- `pyproject.toml` set `exclude = ["tests/*"]`, and `tox -e ruff` runs
  `ruff check` without a path, so the exclusion applied during traversal.
- The `ruff-check` pre-commit hook carried its own `exclude: ^tests/`.

Both are gone. Removing only the first would not have been enough: ruff honours
`exclude` for explicitly named files only under `force-exclude`, and pre-commit
passes filenames, so the hook's own exclude was the binding one at commit time.

## Security-relevant rules

Unchanged on `app/`: all 58 stable `flake8-bandit` (`S`) rules were already
enabled there, and no `S` rule is ignored repository-wide. `tests/` gains 50 of
the 58 — the eight exceptions are the false-positive-by-construction ones
(`S101`, `S104`, `S105`, `S106`, `S108`, `S314`, `S603`, `S607`), each with a
reason recorded. `S602`, `subprocess` with `shell=True`, stays enabled in test
code.

## Other notes

- `TCH` is superseded by `TC`. It was still accepted with no deprecation notice,
  so nothing reported that the prefix predated the rename.
- The `Q00x` ignores present in the first version of the standard are absent here:
  measured across the seven consumer repositories they silence nothing, and the
  decision now sits in `format.quote-style` where the formatter reads it. Same
  change on the Python template.

## References

- Decision: `SchweizerischeBundesbahnen/weasyprint-service` issue 223
- Definition: `open-source-polarion-python-repo-template` pull request 130
